### PR TITLE
feat(pack): add previous user count tracking to optimize pack opening…

### DIFF
--- a/src/commands/pack.py
+++ b/src/commands/pack.py
@@ -13,6 +13,7 @@ class PackCommand(BaseCommand):
         super().__init__(controller)
         self.handler = self.soul_handler
         self.auto_mode = False
+        self.previous_count = 0  # Track previous user count
 
     async def process(self, message_info, parameters):
         """Process pack command to open luck pack"""
@@ -42,9 +43,12 @@ class PackCommand(BaseCommand):
 
             try:
                 count = int(''.join(filter(str.isdigit, count_text)))
-                if count > 5:
-                    self.auto_mode = True  # Auto mode
-                    self.open_luck_pack(user_count=count)  # Pass user count as parameter
+                # Only check if count has changed
+                if count != self.previous_count:
+                    self.previous_count = count  # Update previous count
+                    if count > 5:
+                        self.auto_mode = True  # Auto mode
+                        self.open_luck_pack(user_count=count)  # Pass user count as parameter
             except ValueError:
                 self.handler.logger.error(f"Failed to parse user count: {count_text}")
 


### PR DESCRIPTION
… logic

- Introduced a mechanism to track the previous user count, preventing unnecessary pack openings when the count remains unchanged.
- Enhanced the process method to only trigger the auto mode and pack opening if the user count exceeds 5 and has changed since the last check.